### PR TITLE
Fix a minor typo in the Exercises under SageMath Objects - Universes and Coercion

### DIFF
--- a/sageprog.rst
+++ b/sageprog.rst
@@ -773,7 +773,7 @@ this style of programming with python see the `Python Documentation`_.
      d) Remove the ``M`` that you  just inserted.
      e) Explain the differences between the :meth:`.extend` and the :meth:`.append` methods.
 
-  #. Let ``L = [1,2,5, 14, 17, 20]``.  What are the sub-lists are accessed using the following *slices*.
+  #. Let ``L = [1,2,5, 14, 17, 20]``.  What are the sub-lists that are accessed using the following *slices*.
 
      a) ``L[:-1]``
      b) ``L[-1:]``

--- a/sageprog.rst
+++ b/sageprog.rst
@@ -155,7 +155,7 @@ And in case we try to make *some* nonsensical conversions, SageMath will raise a
      c) ``1/2 + i``
      d) ``e + pi``
      e) ``e.n() + pi``
-     f) ``e.n() + pi.()``
+     f) ``e.n() + pi.n()``
 
   #. For which of the following does the *coercion* make sense?
 


### PR DESCRIPTION
* Fix a minor typo in the Exercises under SageMath Objects - Universes and Coercion.  In particular, pi.() has invalid syntax.
* Fix a minor typo under Operations on a List.